### PR TITLE
mgmt: hawkbit: make server address and port settable during runtime

### DIFF
--- a/include/zephyr/mgmt/hawkbit.h
+++ b/include/zephyr/mgmt/hawkbit.h
@@ -64,6 +64,24 @@ void hawkbit_autohandler(void);
 enum hawkbit_response hawkbit_probe(void);
 
 /**
+ * @brief Set the Hawkbit server address.
+ *
+ * @param addr_str Server address to set.
+ * @return 0 on success.
+ * @return -EAGAIN if probe is currently running.
+ */
+int hawkbit_set_server_addr(char *addr_str);
+
+/**
+ * @brief Set the Hawkbit server port.
+ *
+ * @param port Server port to set.
+ * @return 0 on success.
+ * @return -EAGAIN if probe is currently running.
+ */
+int hawkbit_set_server_port(uint16_t port);
+
+/**
  * @}
  */
 

--- a/subsys/mgmt/hawkbit/hawkbit.c
+++ b/subsys/mgmt/hawkbit/hawkbit.c
@@ -100,7 +100,7 @@ static union {
 
 static struct k_work_delayable hawkbit_work_handle;
 
-static struct k_sem probe_sem;
+K_SEM_DEFINE(probe_sem, 1, 1);
 
 static const struct json_obj_descr json_href_descr[] = {
 	JSON_OBJ_DESCR_PRIM(struct hawkbit_href, href, JSON_TOK_STRING),
@@ -615,7 +615,6 @@ int hawkbit_init(void)
 		}
 	}
 
-	k_sem_init(&probe_sem, 1, 1);
 
 	return ret;
 }


### PR DESCRIPTION
In situations, where the address and the port of the hawkbit server is not known during build, it should be possibel to set it during runtime.